### PR TITLE
fix: use strings.ReplaceAll for staticcheck QF1004 compliance

### DIFF
--- a/handlers/root.go
+++ b/handlers/root.go
@@ -54,7 +54,7 @@ func rootPost(w http.ResponseWriter, r *http.Request, c aws.Service, s slack.Ser
 	// Note: AWS sends us an opaque token, but it's essentially a base64 string,
 	// and + is a valid base64 character (see https://datatracker.ietf.org/doc/html/rfc4648#section-4),
 	// but browsers will convert it to a space when POSTed as part of a form. So, we hackily convert it back here.
-	unescapedToken = strings.Replace(unescapedToken, " ", "+", -1)
+	unescapedToken = strings.ReplaceAll(unescapedToken, " ", "+")
 
 	customerData, err := c.FetchCustomerData(unescapedToken)
 	if err != nil {


### PR DESCRIPTION
This PR fixes a staticcheck (QF1004) linter warning by replacing the use of `strings.Replace` with `strings.ReplaceAll` in `handlers/root.go`.

- Replaces `strings.Replace(unescapedToken, " ", "+", -1)` with `strings.ReplaceAll(unescapedToken, " ", "+")`
- Passes all tests and linter checks

Closes https://github.com/giantswarm/giantswarm/issues/33041
