### PR TITLE
fix: add .ats/main.yaml so execute-chart-tests passes without ATS scenarios

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -1,0 +1,6 @@
+# ATS (app-test-suite) config for the generated execute-chart-tests CI job.
+# This repo has no ATS test scenarios yet; skip the scenario steps so the
+# chart validation part of ATS can pass. Remove skip-steps when tests exist.
+smoke-tests-cluster-type: kind
+upgrade-tests-cluster-type: kind
+skip-steps: [smoke,functional,upgrade]


### PR DESCRIPTION
## Problem

`ci/circleci: execute-chart-tests` (and `execute-chart-tests-release` on main/tags) fails on every run with:

```
Error for config option '--smoke-tests-cluster-type': Unknown cluster type 'None' requested for tests of type 'smoke'. Known cluster types are: '['external', 'kind']'.
```

The generated CircleCI config wires `architect/run-tests-with-ats`, but ATS reads its config from `.ats/main.yaml`, which this repo does not have. Without it the SmokeTestScenario pre-run step fails before anything is tested. This also fails identically on main (build 1136), so every PR shows a red non-required check.

## Solution

Add `.ats/main.yaml` declaring cluster types and skipping the scenario steps (this repo has no ATS test scenarios) -- the same pattern muster uses. When real ATS tests are added, drop `skip-steps`.

Made with [Cursor](https://cursor.com)